### PR TITLE
Replaces email field with username in Devise authentication

### DIFF
--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -2,10 +2,8 @@ class ApplicationController < ActionController::Base
   # Prepend protect_from_forgery to the before_action chain manually
   protect_from_forgery prepend: true
 
-  # Call the configured parameters
   before_action :configure_permitted_parameters, if: :devise_controller?
 
-  # Allow selected fields to be updated during mass assignment
   protected
 
   def configure_permitted_parameters

--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -1,4 +1,20 @@
 class ApplicationController < ActionController::Base
   # Prepend protect_from_forgery to the before_action chain manually
   protect_from_forgery prepend: true
+
+  # Call the configured parameters
+  before_action :configure_permitted_parameters, if: :devise_controller?
+
+  # Allow selected fields to be updated during mass assignment
+  protected
+
+    def configure_permitted_parameters
+      devise_parameter_sanitizer.permit(:sign_up, keys: %i[username
+                                                           email password
+                                                           password_confirmation
+                                                           remember_me])
+      devise_parameter_sanitizer.permit(:sign_in, keys: %i[username
+                                                           email password
+                                                           password_confirmation])
+    end
 end

--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -8,13 +8,13 @@ class ApplicationController < ActionController::Base
   # Allow selected fields to be updated during mass assignment
   protected
 
-    def configure_permitted_parameters
-      devise_parameter_sanitizer.permit(:sign_up, keys: %i[username
-                                                           email password
-                                                           password_confirmation
-                                                           remember_me])
-      devise_parameter_sanitizer.permit(:sign_in, keys: %i[username
-                                                           email password
-                                                           password_confirmation])
-    end
+  def configure_permitted_parameters
+    devise_parameter_sanitizer.permit(:sign_up, keys: %i[username
+                                                         email password
+                                                         password_confirmation
+                                                         remember_me])
+    devise_parameter_sanitizer.permit(:sign_in, keys: %i[username
+                                                         email password
+                                                         password_confirmation])
+  end
 end

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -3,4 +3,6 @@ class User < ApplicationRecord
   # :confirmable, :lockable, :timeoutable, :trackable and :omniauthable
   devise :database_authenticatable, :registerable,
          :recoverable, :rememberable, :validatable
+
+  validates :username, length: { maximum: 30 }
 end

--- a/app/views/devise/registrations/new.html.haml
+++ b/app/views/devise/registrations/new.html.haml
@@ -2,6 +2,10 @@
 = form_for(resource, as: resource_name, url: registration_path(resource_name)) do |f|
   = render "devise/shared/error_messages", resource: resource
   .field
+    = f.label :username
+    %br/
+    = f.text_field :username, autofocus: true
+  .field
     = f.label :email
     %br/
     = f.email_field :email, autofocus: true, autocomplete: "email"

--- a/app/views/devise/sessions/new.html.haml
+++ b/app/views/devise/sessions/new.html.haml
@@ -1,9 +1,9 @@
 %h2 Log in
 = form_for(resource, as: resource_name, url: session_path(resource_name)) do |f|
   .field
-    = f.label :email
+    = f.label :username
     %br/
-    = f.email_field :email, autofocus: true, autocomplete: "email"
+    = f.text_field :username, autofocus: true
   .field
     = f.label :password
     %br/

--- a/app/views/devise/sessions/new.html.haml
+++ b/app/views/devise/sessions/new.html.haml
@@ -2,11 +2,11 @@
 = form_for(resource, as: resource_name, url: session_path(resource_name)) do |f|
   .field
     = f.label :username
-    %br/
+    %br
     = f.text_field :username, autofocus: true
   .field
     = f.label :password
-    %br/
+    %br
     = f.password_field :password, autocomplete: "current-password"
   - if devise_mapping.rememberable?
     .field

--- a/config/initializers/devise.rb
+++ b/config/initializers/devise.rb
@@ -18,7 +18,7 @@ Devise.setup do |config|
   # Configure the e-mail address which will be shown in Devise::Mailer,
   # note that it will be overwritten if you use your own mailer class
   # with default "from" parameter.
-  config.mailer_sender = 'please-change-me-at-config-initializers-devise@example.com'
+  config.mailer_sender = "please-change-me-at-config-initializers-devise@example.com"
 
   # Configure the class responsible to send e-mails.
   # config.mailer = 'Devise::Mailer'
@@ -30,7 +30,7 @@ Devise.setup do |config|
   # Load and configure the ORM. Supports :active_record (default) and
   # :mongoid (bson_ext recommended) by default. Other ORMs may be
   # available as additional gems.
-  require 'devise/orm/active_record'
+  require "devise/orm/active_record"
 
   # ==> Configuration for any authentication mechanism
   # Configure which keys are used when authenticating a user. The default is
@@ -40,7 +40,7 @@ Devise.setup do |config|
   # session. If you need permissions, you should implement that in a before filter.
   # You can also supply a hash where the value is a boolean determining whether
   # or not authentication should be aborted when the value is not present.
-  # config.authentication_keys = [:email]
+  config.authentication_keys = [:username]
 
   # Configure parameters from the request object used for authentication. Each entry
   # given should be a request method and it will automatically be passed to the

--- a/db/migrate/20190530033104_add_username_to_users.rb
+++ b/db/migrate/20190530033104_add_username_to_users.rb
@@ -1,0 +1,6 @@
+class AddUsernameToUsers < ActiveRecord::Migration[5.2]
+  def change
+    add_column :users, :username, :string, limit: 30
+    add_index :users, :username, unique: true
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 2019_05_29_035029) do
+ActiveRecord::Schema.define(version: 2019_05_30_033104) do
 
   create_table "tweets", options: "ENGINE=InnoDB DEFAULT CHARSET=utf8", force: :cascade do |t|
     t.string "tweet"
@@ -26,8 +26,10 @@ ActiveRecord::Schema.define(version: 2019_05_29_035029) do
     t.datetime "remember_created_at"
     t.datetime "created_at", null: false
     t.datetime "updated_at", null: false
+    t.string "username", limit: 30
     t.index ["email"], name: "index_users_on_email", unique: true
     t.index ["reset_password_token"], name: "index_users_on_reset_password_token", unique: true
+    t.index ["username"], name: "index_users_on_username", unique: true
   end
 
 end


### PR DESCRIPTION
## Changes
* Creates a migration file that adds the username column in Devise's users table
* Adds strong parameter permissions during sign_up and sign_in to protect attributes from end user mass assignment
* Adds username field in the sign up form
* Replaces email with username field in the sign in form

## Steps to Test Changes
1. Drop database if there's an existing one via `rails db:drop`
2. Use `rails db:create db:migrate` to re-create database and re-run migrations
3. Insert sample data to the database for testing via
  * `rails console`
  * `@user = User.create :username => "sample", :email => "sample@email.com", :password => "sample", :password_confirmation => "sample"`
4. Start the local server with: `rails s` or `rails server` then proceed to `localhost:3000/users/sign_in` then log in with the previously inserted data
5. The application should redirect you to a blank page in `localhost:3000` 

## References
* https://api.rubyonrails.org/classes/ActiveRecord/Migration.html
* https://edgeapi.rubyonrails.org/classes/ActionController/StrongParameters.html
* https://github.com/mashupgarage/skippr/blob/develop/app/controllers/application_controller.rb
* https://stackoverflow.com/questions/10866667/devise-authenticating-with-username-instead-of-email
* https://github.com/plataformatec/devise/wiki/How-To:-Allow-users-to-sign-in-with-something-other-than-their-email-address
* https://stackoverflow.com/questions/2489599/how-to-add-data-to-database-from-rails-console