### PR TITLE
Implements sign out to the authentication feature

### DIFF
--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -15,4 +15,10 @@ class ApplicationController < ActionController::Base
                                                          email password
                                                          password_confirmation])
   end
+
+  private
+
+  def after_sign_out_path_for(resource_or_scope)
+    new_user_session_path
+  end
 end

--- a/app/javascript/packs/stylesheets.scss
+++ b/app/javascript/packs/stylesheets.scss
@@ -1,2 +1,5 @@
 // Bootstrap
 @import '~bootstrap/scss/bootstrap';
+
+// Custom Styles
+@import '../src/styles/custom';

--- a/app/javascript/src/styles/_custom.scss
+++ b/app/javascript/src/styles/_custom.scss
@@ -1,5 +1,5 @@
 // Remove left dropdown menu oddities
 .ml-auto .dropdown-menu {
-  left: auto !important;
+  left: auto;
   right: 0px;
 }

--- a/app/javascript/src/styles/_custom.scss
+++ b/app/javascript/src/styles/_custom.scss
@@ -1,0 +1,5 @@
+// Remove left dropdown menu oddities
+.ml-auto .dropdown-menu {
+  left: auto !important;
+  right: 0px;
+}

--- a/app/views/devise/registrations/new.html.haml
+++ b/app/views/devise/registrations/new.html.haml
@@ -1,36 +1,37 @@
-.card.m-5
-  .card-header
-    %h5 Sign up to Journey
-  .card-body
-    .container
+.container
+  .card.m-5
+    .card-header
+      %h5 Sign up to Journey
+    .card-body
+      .container
 
-      %br/
+        %br/
 
-      = form_for(resource, as: resource_name, url: registration_path(resource_name), html: {class: "col-md-8 offset-md-2"}) do |f|
-        = render "devise/shared/error_messages", resource: resource
+        = form_for(resource, as: resource_name, url: registration_path(resource_name), html: {class: "col-md-8 offset-md-2"}) do |f|
+          = render "devise/shared/error_messages", resource: resource
 
-        .form-group
-          = f.label :username
-          = f.text_field :username, autofocus: true, class: "form-control"
-          %small#usernameHelpBlock.form-text.text-muted Your username must be 8-20 characters long, may contain letters and numbers, and must not contain spaces, special characters, or emoji.
+          .form-group
+            = f.label :username
+            = f.text_field :username, autofocus: true, class: "form-control"
+            %small#usernameHelpBlock.form-text.text-muted Your username must be 8-20 characters long, may contain letters and numbers, and must not contain spaces, special characters, or emoji.
 
-        .form-group
-          = f.label :email
-          = f.email_field :email, autofocus: true, autocomplete: "email", class: "form-control"
-          %small#emailHelpBlock.form-text.text-muted Please use your personal email for privacy and security.
+          .form-group
+            = f.label :email
+            = f.email_field :email, autofocus: true, autocomplete: "email", class: "form-control"
+            %small#emailHelpBlock.form-text.text-muted Please use your personal email for privacy and security.
 
-        .form-group
-          = f.label :password
-          = f.password_field :password, autocomplete: "new-password", class: "form-control"
-          %small#usernameHelpBlock.form-text.text-muted Your username must be 6-30 characters long, may contain letters and numbers, and must not contain spaces, special characters, or emoji.
+          .form-group
+            = f.label :password
+            = f.password_field :password, autocomplete: "new-password", class: "form-control"
+            %small#usernameHelpBlock.form-text.text-muted Your username must be 6-30 characters long, may contain letters and numbers, and must not contain spaces, special characters, or emoji.
 
-        .form-group
-          = f.label :password_confirmation
-          %br/
-          = f.password_field :password_confirmation, autocomplete: "new-password", class: "form-control"
-          %small#confirmPasswordHelpBlock.form-text.text-muted Your password confirmation must match the previously filled password field.
+          .form-group
+            = f.label :password_confirmation
+            %br/
+            = f.password_field :password_confirmation, autocomplete: "new-password", class: "form-control"
+            %small#confirmPasswordHelpBlock.form-text.text-muted Your password confirmation must match the previously filled password field.
 
-        .form-group.pt-2
-          = f.submit "Sign up", class: "btn btn-primary btn-lg btn-block"
-        
-        = render "devise/shared/links"
+          .form-group.pt-2
+            = f.submit "Sign up", class: "btn btn-primary btn-lg btn-block"
+
+          = render "devise/shared/links"

--- a/app/views/devise/registrations/new.html.haml
+++ b/app/views/devise/registrations/new.html.haml
@@ -5,7 +5,7 @@
     .card-body
       .container
 
-        %br/
+        %br
 
         = form_for(resource, as: resource_name, url: registration_path(resource_name), html: {class: "col-md-8 offset-md-2"}) do |f|
           = render "devise/shared/error_messages", resource: resource
@@ -27,7 +27,7 @@
 
           .form-group
             = f.label :password_confirmation
-            %br/
+            %br
             = f.password_field :password_confirmation, autocomplete: "new-password", class: "form-control"
             %small#confirmPasswordHelpBlock.form-text.text-muted Your password confirmation must match the previously filled password field.
 

--- a/app/views/devise/sessions/new.html.haml
+++ b/app/views/devise/sessions/new.html.haml
@@ -1,29 +1,30 @@
-.pt-5
-  .card.m-5
-    .row.no-gutters
-      .col-md-4
-        %img.card-img(src="https://picsum.photos/200/300")/
-      .col-md-8
-        .card-body
-          .container
-            = form_for(resource, as: resource_name, url: session_path(resource_name), html: {class: "col-md-12 pt-4"}) do |f|
-              
-              %h2 Sign in to Journey
-              
-              .form-group.pt-5
-                = f.label :username
-                = f.text_field :username, autofocus: true, class: "form-control"
-              
-              .form-group
-                = f.label :password
-                = f.password_field :password, autocomplete: "current-password", class: "form-control"
-              
-              - if devise_mapping.rememberable?
-                .form-check
-                  = f.check_box :remember_me, class: "form-check-input"
-                  = f.label :remember_me, class: "form-check-label"
-              
-              .form-group.pt-3
-                = f.submit "Sign in", class: "btn btn-primary btn-lg btn-block"
-              
-              = render "devise/shared/links"
+.container
+  .pt-5
+    .card.m-5
+      .row.no-gutters
+        .col-md-4
+          %img.card-img(src="https://picsum.photos/200/300")/
+        .col-md-8
+          .card-body
+            .container
+              = form_for(resource, as: resource_name, url: session_path(resource_name), html: {class: "col-md-12 pt-4"}) do |f|
+
+                %h2 Sign in to Journey
+
+                .form-group.pt-5
+                  = f.label :username
+                  = f.text_field :username, autofocus: true, class: "form-control"
+
+                .form-group
+                  = f.label :password
+                  = f.password_field :password, autocomplete: "current-password", class: "form-control"
+
+                - if devise_mapping.rememberable?
+                  .form-check
+                    = f.check_box :remember_me, class: "form-check-input"
+                    = f.label :remember_me, class: "form-check-label"
+
+                .form-group.pt-3
+                  = f.submit "Sign in", class: "btn btn-primary btn-lg btn-block"
+
+                = render "devise/shared/links"

--- a/app/views/devise/sessions/new.html.haml
+++ b/app/views/devise/sessions/new.html.haml
@@ -3,7 +3,7 @@
     .card.m-5
       .row.no-gutters
         .col-md-4
-          %img.card-img(src="https://picsum.photos/200/300")/
+          = image_tag "https://picsum.photos/200/300", class: "card-img"
         .col-md-8
           .card-body
             .container

--- a/app/views/layouts/_nav.html.haml
+++ b/app/views/layouts/_nav.html.haml
@@ -1,0 +1,12 @@
+%nav.navbar.navbar-expand-lg.navbar-light.bg-light
+  %a.navbar-brand(href="#") Journey
+  %button.navbar-toggler(type="button" data-toggle="collapse" data-target="#navbarNavDropdown" aria-controls="navbarNavDropdown" aria-expanded="false" aria-label="Toggle navigation")
+    %span.navbar-toggler-icon
+  .collapse.navbar-collapse#navbarNavDropdown
+    %ul.navbar-nav.ml-auto
+      %li.nav-item.dropdown
+        %a.nav-link.dropdown-toggle#navbarDropdownMenuLink(href="#" role="button" data-toggle="dropdown" aria-haspopup="true" aria-expanded="false")
+        .dropdown-menu
+          %a.dropdown-item(href="#") Profile
+          %a.dropdown-item(href="#") Settings
+          = link_to('Sign Out', destroy_user_session_path, method: :delete, class: "dropdown-item")

--- a/app/views/layouts/_nav.html.haml
+++ b/app/views/layouts/_nav.html.haml
@@ -1,12 +1,11 @@
 %nav.navbar.navbar-expand-lg.navbar-light.bg-light
-  %a.navbar-brand(href="#") Journey
-  %button.navbar-toggler(type="button" data-toggle="collapse" data-target="#navbarNavDropdown" aria-controls="navbarNavDropdown" aria-expanded="false" aria-label="Toggle navigation")
-    %span.navbar-toggler-icon
+  = link_to "Journey", "#", class: "navbar-brand"
+  = button_tag "Test", class: "navbar-toggler", type: "button", data: { toggle: "collapse", target: "#navbarNavDropdown" }, aria: { controls: "navbarNavDropdown", expanded: "false", label: "Toggle Navigation" }
   .collapse.navbar-collapse#navbarNavDropdown
     %ul.navbar-nav.ml-auto
       %li.nav-item.dropdown
-        %a.nav-link.dropdown-toggle#navbarDropdownMenuLink(href="#" role="button" data-toggle="dropdown" aria-haspopup="true" aria-expanded="false")
+        = link_to "", "#", class: "nav-link dropdown-toggle", id: "navbarDropdownMenuLink", role: "button", data: { toggle: "dropdown" }, aria: { haspopup: "true", expanded: "false" }
         .dropdown-menu
-          %a.dropdown-item(href="#") Profile
-          %a.dropdown-item(href="#") Settings
-          = link_to('Sign Out', destroy_user_session_path, method: :delete, class: "dropdown-item")
+          = link_to "Profile", "#", class: "dropdown-item"
+          = link_to "Settings", "#", class: "dropdown-item"
+          = link_to "Sign Out", destroy_user_session_path, method: :delete, class: "dropdown-item"

--- a/app/views/layouts/application.html.haml
+++ b/app/views/layouts/application.html.haml
@@ -8,5 +8,4 @@
     = stylesheet_pack_tag 'application', media: 'all', 'data-turbolinks-track': 'reload'
     = javascript_pack_tag 'application', 'data-turbolinks-track': 'reload'
   %body
-    .container
-      = yield
+    = yield

--- a/app/views/pages/index.html.haml
+++ b/app/views/pages/index.html.haml
@@ -1,0 +1,1 @@
+= render 'layouts/nav'


### PR DESCRIPTION
## Changes
* Adds a navigation bar layout within the main application
* Removes container class from the main layout file
* Includes container to the sign up and sign in pages

## Screenshots

### Without overriding Bootstrap classes
![screely-1560224968022](https://user-images.githubusercontent.com/21337635/59242734-4cc02580-8c3f-11e9-80d2-58caa3cec114.png)

### Overriding Bootstrap classes
![screely-1560225029428](https://user-images.githubusercontent.com/21337635/59242749-606b8c00-8c3f-11e9-84c2-50288de8718e.png)

## References
* https://stackoverflow.com/questions/25537881/how-can-i-make-my-navbar-appear-on-every-page-in-my-rails-app
* https://getbootstrap.com/docs/4.3/components/navbar/
* https://stackoverflow.com/questions/10374322/haml-link-to-vs-button-to
* https://github.com/plataformatec/devise/wiki/How-To:-Add-sign_in,-sign_out,-and-sign_up-links-to-your-layout-template